### PR TITLE
Fix subgroup orientation error that occurs with non-categorical axes

### DIFF
--- a/chartify/_core/axes.py
+++ b/chartify/_core/axes.py
@@ -191,8 +191,15 @@ class BaseAxes:
         level_3 = self._convert_subgroup_orientation_labels(level_3)
 
         self._chart.figure.xaxis.major_label_orientation = level_1
-        self._chart.figure.xaxis.subgroup_label_orientation = level_2
-        self._chart.figure.xaxis.group_label_orientation = level_3
+
+        xaxis = self._chart.figure.xaxis[0]
+        has_subgroup_label = getattr(xaxis, 'subgroup_label_orientation', None)
+        if has_subgroup_label is not None:
+            self._chart.figure.xaxis.subgroup_label_orientation = level_2
+
+        has_group_label = getattr(xaxis, 'group_label_orientation', None)
+        if has_group_label is not None:
+            self._chart.figure.xaxis.group_label_orientation = level_3
         return self._chart
 
 

--- a/chartify/_core/chart.py
+++ b/chartify/_core/chart.py
@@ -186,7 +186,7 @@ y_axis_type='{y_axis_type}')
         source_font_size = '10px'
         _source = bokeh.models.Label(
             x=self.style.plot_width * .9,
-            y=-55,
+            y=0,
             x_units='screen',
             y_units='screen',
             level='overlay',
@@ -195,7 +195,7 @@ y_axis_type='{y_axis_type}')
             text_font_size=source_font_size,
             text_align='right',
             name='subtitle')
-        self.figure.add_layout(_source)
+        self.figure.add_layout(_source, 'below')
         return _source
 
     @property

--- a/chartify/_core/chart.py
+++ b/chartify/_core/chart.py
@@ -162,9 +162,10 @@ y_axis_type='{y_axis_type}')
     def _add_subtitle_to_figure(self, subtitle_text=None):
         """Create the subtitle glyph and add it to the bokeh figure."""
         if subtitle_text is None:
-            subtitle_text = """ch.set_subtitle('Data Description')"""
-        if self._blank_labels:
-            subtitle_text = ""
+            if self._blank_labels:
+                subtitle_text = ""
+            else:
+                subtitle_text = """ch.set_subtitle('Data Description')"""
         subtitle_settings = self.style._get_settings('subtitle')
         _subtitle_glyph = bokeh.models.Title(
             text=subtitle_text,

--- a/tests/test_axes.py
+++ b/tests/test_axes.py
@@ -107,7 +107,7 @@ class TestBaseAxes:
 
         quantity_by_date = data.groupby('date')['quantity'].sum().reset_index()
         ch = chartify.Chart(x_axis_type='datetime')
-        ch.plot.line(df, 'date', 'quantity')
+        ch.plot.line(quantity_by_date, 'date', 'quantity')
         assert ch.figure.xaxis[0].major_label_orientation == 'horizontal'
 
         ch.axes.set_xaxis_tick_orientation('vertical')

--- a/tests/test_axes.py
+++ b/tests/test_axes.py
@@ -104,3 +104,12 @@ class TestBaseAxes:
         assert ch.figure.yaxis[0].major_label_orientation == 'horizontal'
         assert ch.figure.yaxis[0].subgroup_label_orientation == 'normal'
         assert ch.figure.yaxis[0].group_label_orientation == 'normal'
+
+        quantity_by_date = data.groupby('date')['quantity'].sum().reset_index()
+        ch = chartify.Chart(x_axis_type='datetime')
+        ch.plot.line(df, 'date', 'quantity')
+        assert ch.figure.xaxis[0].major_label_orientation == 'horizontal'
+
+        ch.axes.set_xaxis_tick_orientation('vertical')
+        assert np.allclose(ch.figure.xaxis[0].major_label_orientation,
+                           1.5707963267948966)


### PR DESCRIPTION
- Fixed: #32: xaxis orientation with datetime axis.
- Fixed #34: subtitle covered by outside_top legend
- Also fixed overlap issue with source label and xaxis labels