### PR TITLE
Make 'import chartify' expr defer to previous call to 'bokeh.io.output_notebook'

### DIFF
--- a/chartify/__init__.py
+++ b/chartify/__init__.py
@@ -32,14 +32,18 @@ def set_display_settings():
     from ipykernel.zmqshell import ZMQInteractiveShell
     from bokeh.io import output_notebook
     from bokeh.resources import Resources
+    from bokeh.io.state import curstate
 
     ipython_instance = get_ipython()
     if ipython_instance is not None:
         if isinstance(ipython_instance, ZMQInteractiveShell):
             _IPYTHON_INSTANCE = True
-            # Inline resources uses bokeh.js from the local version.
-            # This enables offline usage.
-            output_notebook(Resources('inline'))
+            # Defer to previous call to ``output_notebook`` so that users
+            # can specify their own notebook type and Bokeh resources
+            if curstate().notebook_type is None:
+                # Inline resources uses bokeh.js from the local version.
+                # This enables offline usage.
+                output_notebook(Resources('inline'))
 
 
 set_display_settings()


### PR DESCRIPTION
**What this PR does / why we need it**:
Allows users to specify their own Bokeh/notebook configurations (including specifying resources).

Example code:
```
# loads resources from CDN
from bokeh.io import output_notebook
output_notebook()

# load chartify package into namespace but defer to above bokeh.io.output_notebook call
import chartify
```

**Which issue(s) this PR fixes**
Fixes #47

**Special notes for your reviewer**:
It's unclear where to best document (and test) this feature because it's part of import behavior. Please advise.

**Release note**:
```release-note
None
```
