### PR TITLE
Hide the 'BokehJS x.y.z successfully loaded.' from 'import chartify' expr output

### DIFF
--- a/chartify/__init__.py
+++ b/chartify/__init__.py
@@ -39,7 +39,7 @@ def set_display_settings():
             _IPYTHON_INSTANCE = True
             # Inline resources uses bokeh.js from the local version.
             # This enables offline usage.
-            output_notebook(Resources('inline'))
+            output_notebook(Resources('inline'), hide_banner=True)
 
 
 set_display_settings()


### PR DESCRIPTION
**What this PR does / why we need it**:
Removes the ``BokehJS x.y.z successfully loaded.`` output from the ``import chartify`` expression.

**Which issue(s) this PR fixes**
Fixes #49 

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
