### PR TITLE
Fix the axis precision when the max value equals to the min value

### DIFF
--- a/chartify/_core/plot.py
+++ b/chartify/_core/plot.py
@@ -36,7 +36,8 @@ class BasePlot:
     @staticmethod
     def _axis_format_precision(max_value, min_value):
         difference = abs(max_value - min_value)
-        precision = abs(int(np.floor(np.log10(difference)))) + 1
+        precision = abs(int(np.floor(
+            np.log10(difference if difference else 1)))) + 1
         zeros = ''.join(['0']*precision)
         return "0,0.[{}]".format(zeros)
 

--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -491,6 +491,7 @@ class TestAxisFormatPrecision:
 
     def setup(self):
         self.tests = {
+            (0, 0): "0,0.[0]",
             (0, 0.004): "0,0.[0000]",
             (0, 0.04): "0,0.[000]",
             (0, 0.4): "0,0.[00]",


### PR DESCRIPTION
**What this PR does / why we need it**:

In the method BasePlot._axis_format_precision, when max_value = min_value, an OverflowError will be raised. We should pass a positive number to the log function here.

**Which issue(s) this PR fixes**
<!-- optional; in `fixes #<issue number>, fixes #<issue_number>, ...` format, will close the issue(s) when PR gets merged: -->
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, start the release note with the string "action required: ".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
