### PR TITLE
Bump Pandas requirement to 1.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,9 @@
 
 language: python
 python:
-  - 3.5
   - 3.6
+  - 3.7
+  - 3.8
 
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install: pip install -U tox-travis

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pandas>=0.21.0,<1.0.0
+pandas>=1.0.0<2.0.0
 jupyter>=1.0.0,<2.0.0
 Pillow>=6.2.0
 # Avoid selenium bug:

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,3 +1,5 @@
+-r requirements.txt
+
 -e .
 twine==1.11.0
 watchdog==0.8.3
@@ -14,11 +16,4 @@ pytest==3.2.3
 pytest-cov==2.5.1
 coverage-badge==0.2.0
 pytest-runner==2.11.1
-pandas==0.23.4
-jupyter==1.0.0
 pylint==1.7.4
-Pillow==6.2.0
-selenium==3.8.0
-bokeh==1.4.0
-scipy==1.3.0
-colour==0.1.5

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -4,7 +4,7 @@
 twine==1.11.0
 watchdog==0.8.3
 flake8==2.6.0
-tox==2.3.1
+tox>=3.13.2
 coverage==4.1
 Sphinx==1.7.7
 commonmark==0.5.4

--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -412,7 +412,7 @@ class TestBarLollipopParallel:
                 chart_data(ch, '')['number'], [10, 5, 0, 4, -3]))
             multi_index = pd.MultiIndex(
                 levels=[['a', 'b'], ['1', '2', '3']],
-                labels=[[0, 0, 0, 1, 1], [1, 0, 2, 0, 1]],
+                codes=[[0, 0, 0, 1, 1], [1, 0, 2, 0, 1]],
                 names=['category1', 'category2'])
             assert (np.array_equal(chart_data(ch, '')['factors'], multi_index))
 
@@ -426,7 +426,7 @@ class TestBarLollipopParallel:
                 chart_data(ch, '')['number'], [5, 4, 10, -3, 0]))
             multi_index = pd.MultiIndex(
                 levels=[['1', '2', '3'], ['a', 'b']],
-                labels=[[0, 0, 1, 1, 2], [0, 1, 0, 1, 0]],
+                codes=[[0, 0, 1, 1, 2], [0, 1, 0, 1, 0]],
                 names=['category2', 'category1'])
             assert (np.array_equal(chart_data(ch, '')['factors'], multi_index))
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,13 @@
 [tox]
-envlist = py36, py35
+envlist = py36, py37, py38, py39
 skipsdist = True
 usedevelop = True
 
 [travis]
 python =
+    3.8: py38
+    3.7: py37
     3.6: py36
-    3.5: py35
 
 [testenv]
 setenv =


### PR DESCRIPTION
**What this PR does / why we need it**:

Pandas 1.0 has been out for a few months, and seems stable enough that we should start supporting it!

In addition, I noticed some inconsistencies between versions used in the package requirements itself,
and in the requirements specified for local development. These have now been rectified (and future-proofed)
by including the package `requirements.txt` from the dev one instead of specifying everything twice.

**Special notes for your reviewer**:

On my local setup (Windows with WSL) there are some problems with chromedriver that I haven't been
able to figure out. Because of this, saving images as png doesn't work, and thus that test has been
skipped when I've tested locally. I doubt that it would make a difference for this change, but might
be worth double-checking in the PR builds.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, start the release note with the string "action required: ".
2. If no release note is required, just write "NONE".
-->
```release-note
Bump Pandas requirement to 1.0
```