### PR TITLE
Replace deprecated yaml FullLoader

### DIFF
--- a/chartify/_core/colors.py
+++ b/chartify/_core/colors.py
@@ -42,7 +42,7 @@ class CustomColors:
 
     def from_yaml(self, filename):
         """Load colors from yaml file"""
-        return yaml.load(open(filename), Loader=yaml.FullLoader)
+        return yaml.load(open(filename), Loader=yaml.SafeLoader)
 
     def overwrite_colors(self):
         """Overwrite colors in the colour module with custom colors."""
@@ -273,7 +273,7 @@ class ColorPalettes:
 
     def _from_yaml(self, filename):
         """Load color palettes from a yaml file"""
-        palette_list = yaml.load(open(filename), Loader=yaml.FullLoader)
+        palette_list = yaml.load(open(filename), Loader=yaml.SafeLoader)
         for palette in palette_list:
             hex_color_list, palette_type, name = palette
             self._add_palette(


### PR DESCRIPTION
See https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation

---
NOTE The FullLoader loader class and full_load function (the current default for load) should be avoided for now. New exploits in 5.3.1 were found in July 2020. These exploits will be addressed in the next release, but if further exploits are found then FullLoader may go away.
---

(The usage in options.py is also unsafe but is explicitly marked as such.)