### PR TITLE
Missed change - legend handling to adjust for deprecated legend keyword

### DIFF
--- a/chartify/_core/plot.py
+++ b/chartify/_core/plot.py
@@ -2020,7 +2020,7 @@ class PlotMixedTypeXY(BasePlot):
                 legend = None
                 sliced_data = data_frame
             else:
-                legend = bokeh.core.properties.value(str(color_value))
+                legend = str(color_value)
                 sliced_data = data_frame[data_frame[color_column] ==
                                          color_value]
             # Filter to only relevant columns.


### PR DESCRIPTION

**Fixes legend error**:
This change belongs with this commit but was likely missed.
https://github.com/spotify/chartify/commit/3af29e8a47fa5257e6faf5f2dd47baa4db1344e3#diff-17b8994a0f281801a29c52fc0dc9491168ac64e795936bc9d6aa663f7892311c

Problem reproduced when plotting with grouping and colors:
```
import chartify
import pandas as pd
df = pd.DataFrame.from_dict({"data":[1,1,2,2,3,3], "group":["a","a","a","b","b","b"]})
ch = chartify.Chart(x_axis_type='categorical')
ch.plot.scatter(
data_frame=df,
categorical_columns="group",
numeric_column="data",
color_column="group",
)
ch.show()
```
<details><summary>Error</summary>
<p>

```
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-1-eae93029a0e8> in <module>
      7 categorical_columns="group",
      8 numeric_column="data",
----> 9 color_column="group",
     10 )
     11 ch.show()

~/.virtualenvs/murph_commonality/lib/python3.7/site-packages/chartify-3.0.3-py3.7.egg/chartify/_core/plot.py in scatter(self, data_frame, categorical_columns, numeric_column, size_column, color_column, color_order, categorical_order_by, categorical_order_ascending, alpha, marker)
   2050                 source=source,
   2051                 marker=marker,
-> 2052                 alpha=alpha
   2053                 )
   2054 

~/.virtualenvs/murph_commonality/lib/python3.7/site-packages/chartify-3.0.3-py3.7.egg/chartify/_core/plot.py in _plot_with_legend(method, **kwargs)
    126 
    127         if legend_label is not None:
--> 128             return method(**kwargs, legend_label=legend_label)
    129         elif legend_group is not None:
    130             return method(**kwargs, legend_group=legend_group)

~/.virtualenvs/murph_commonality/lib/python3.7/site-packages/bokeh/plotting/figure.py in scatter(self, *args, **kwargs)
   1088             return self.circle(*args, **kwargs)
   1089         else:
-> 1090             return self._scatter(*args, marker=marker_type, **kwargs)
   1091 
   1092     def hexbin(self, x, y, size, orientation="pointytop", palette="Viridis256", line_color=None, fill_color=None, aspect_scale=1, **kwargs):

~/.virtualenvs/murph_commonality/lib/python3.7/site-packages/bokeh/plotting/_decorators.py in wrapped(self, *args, **kwargs)
     52             for arg, param in zip(args, sigparams[1:]):
     53                 kwargs[param.name] = arg
---> 54             return create_renderer(glyphclass, self, **kwargs)
     55 
     56         wrapped.__signature__ = Signature(parameters=sigparams)

~/.virtualenvs/murph_commonality/lib/python3.7/site-packages/bokeh/plotting/_renderer.py in create_renderer(glyphclass, plot, **kwargs)
    129         # if it creates a new `LegendItem`, the referenced
    130         # renderer must already be present.
--> 131         update_legend(plot, legend_kwarg, glyph_renderer)
    132 
    133     return glyph_renderer

~/.virtualenvs/murph_commonality/lib/python3.7/site-packages/bokeh/plotting/_legends.py in update_legend(plot, legend_kwarg, glyph_renderer)
     54     kwarg, value = list(legend_kwarg.items())[0]
     55 
---> 56     _LEGEND_KWARG_HANDLERS[kwarg](value, legend, glyph_renderer)
     57 
     58 #-----------------------------------------------------------------------------

~/.virtualenvs/murph_commonality/lib/python3.7/site-packages/bokeh/plotting/_legends.py in _handle_legend_label(label, legend, glyph_renderer)
    129 def _handle_legend_label(label, legend, glyph_renderer):
    130     if not isinstance(label, str):
--> 131         raise ValueError("legend_label value must be a string")
    132     label = value(label)
    133     item = _find_legend_item(label, legend)

ValueError: legend_label value must be a string
```

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, start the release note with the string "action required: ".
2. If no release note is required, just write "NONE".
-->
```release-note

```

</p>
</details>


According to this Bokeh release 1.4.0 when using explicit legend_label, you can no longer pass legend label as a dictionary with "value" key.
https://docs.bokeh.org/en/latest/docs/releases.html#release-1-4-0