### PR TITLE
Change bokeh version requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ Pillow>=6.2.0
 # Avoid selenium bug:
 # https://github.com/SeleniumHQ/selenium/issues/5296
 selenium>=3.7.0,<=3.8.0
-bokeh>=2.0.0,<3.0.0
+bokeh>=2.0.0,<2.3.0
 scipy>=1.0.0,<2.0.0
 ipykernel>=5.0
 ipython>=7.0


### PR DESCRIPTION
Chartify doesn't work with bokeh 2.3.0, so require <2.3.0 for now, until a fix is in place.

/Pelle

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines <https://github.com/spotify/chartify/blob/master/CONTRIBUTING.rst>
2. If the PR is unfinished, please prefix the subject line with [WIP], [DRAFT], or [RFC].
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**
<!-- optional; in `fixes #<issue number>, fixes #<issue_number>, ...` format, will close the issue(s) when PR gets merged: -->
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, start the release note with the string "action required: ".
2. If no release note is required, just write "NONE".
-->
```release-note

```
