### PR TITLE
Fixed categorical_order_by used with array_like

### DIFF
--- a/chartify/_core/plot.py
+++ b/chartify/_core/plot.py
@@ -2003,13 +2003,14 @@ class PlotMixedTypeXY(BasePlot):
 
         axis_factors = data_frame.groupby(categorical_columns).size()
 
+        is_string = isinstance(categorical_order_by, str)
         order_length = getattr(categorical_order_by, "__len__", None)
-        if categorical_order_by == "labels":
+        if is_string and categorical_order_by == "labels":
             axis_factors = axis_factors.sort_index(ascending=categorical_order_ascending).index
-        elif categorical_order_by == "count":
+        elif is_string and categorical_order_by == "count":
             axis_factors = axis_factors.sort_values(ascending=categorical_order_ascending).index
         # User-specified order.
-        elif order_length is not None:
+        elif not is_string and order_length is not None:
             axis_factors = categorical_order_by
         else:
             raise ValueError("""Must be 'count', 'labels', or a list of values.""")

--- a/chartify/_core/plot.py
+++ b/chartify/_core/plot.py
@@ -1014,9 +1014,10 @@ class PlotMixedTypeXY(BasePlot):
         if normalize:
             source = source.div(source.sum(axis=1), axis=0)
 
+        is_string = isinstance(categorical_order_by, str)
         order_length = getattr(categorical_order_by, "__len__", None)
         # Sort the categories
-        if categorical_order_by == "values":
+        if is_string and categorical_order_by == "values":
             # Recursively sort values within each level of the index.
             row_totals = source.sum(axis=1, numeric_only=True)
             row_totals.name = "sum"
@@ -1035,10 +1036,10 @@ class PlotMixedTypeXY(BasePlot):
                 ascending=categorical_order_ascending,
             )
             source = source.reindex(row_totals.index)
-        elif categorical_order_by == "labels":
+        elif is_string and categorical_order_by == "labels":
             source = source.sort_index(axis=0, ascending=categorical_order_ascending)
         # Manual sort
-        elif order_length is not None:
+        elif not is_string and order_length is not None:
             source = source.reindex(categorical_order_by, axis="index")
         else:
             raise ValueError("""Must be 'values', 'labels', or a list of values.""")

--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -794,6 +794,71 @@ class TestHistogram:
         assert (np.array_equal(chart_data(ch, 'b')['min_edge'], [2., 6.]))
 
 
+class TestCategoricalOrderBy:
+    def _assert_order_by_array_like(self, chart):
+        assert (np.array_equal(chart.figure.x_range.factors, ['b', 'd', 'a', 'c']))
+        # check bar data
+        assert (np.array_equal(chart_data(chart, '')['factors'], ['b', 'd', 'a', 'c']))
+        assert (np.array_equal(chart_data(chart, '')['number1'], [3, 1, 4, 2]))
+        # check scatter data
+        assert (np.array_equal(chart_data(chart, 'number1')['factors'], ['a', 'b', 'c', 'd']))
+        assert (np.array_equal(chart_data(chart, 'number1')['number1'], [4, 3, 2, 1]))
+
+    def setup_method(self):
+        self.data1 = pd.DataFrame({
+            'category1': ['a', 'b', 'c', 'd'],
+            'number1': [4, 3, 2, 1],
+        })
+
+        self.data2 = pd.DataFrame({
+            'category2': ['b', 'a', 'b', 'b', 'a', 'c'],
+            'number2': [1, 2, 3, 4, 5, 6]
+        })
+
+    def test_order_by_labels(self):
+        ch = chartify.Chart(x_axis_type='categorical')
+
+        ch.plot.bar(self.data1, ['category1'], 'number1', categorical_order_by='labels')
+        assert (np.array_equal(ch.figure.x_range.factors, ['d', 'c', 'b', 'a']))
+        assert (np.array_equal(chart_data(ch, '')['factors'], ['d', 'c', 'b', 'a']))
+        assert (np.array_equal(chart_data(ch, '')['number1'], [1, 2, 3, 4]))
+
+        ch.plot.scatter(self.data1, ['category1'], 'number1', categorical_order_by='labels')
+        assert (np.array_equal(ch.figure.x_range.factors, ['d', 'c', 'b', 'a']))
+        assert (np.array_equal(chart_data(ch, 'number1')['factors'], ['a', 'b', 'c', 'd']))
+        assert (np.array_equal(chart_data(ch, 'number1')['number1'], [4, 3, 2, 1]))
+
+    def test_order_by_values(self):
+        ch = chartify.Chart(x_axis_type='categorical')
+        ch.plot.bar(self.data1, ['category1'], 'number1', categorical_order_by='values')
+        assert (np.array_equal(chart_data(ch, '')['factors'], ['a', 'b', 'c', 'd']))
+        assert (np.array_equal(chart_data(ch, '')['number1'], [4, 3, 2, 1]))
+
+    def test_order_by_count(self):
+        ch = chartify.Chart(x_axis_type='categorical')
+        ch.plot.scatter(self.data2, ['category2'], 'number2', categorical_order_by='count')
+
+        assert (np.array_equal(ch.figure.x_range.factors, ['b', 'a', 'c']))
+        assert (np.array_equal(chart_data(ch, 'number2')['factors'], ['b', 'a', 'b', 'b', 'a', 'c']))
+        assert (np.array_equal(chart_data(ch, 'number2')['number2'], [1, 2, 3, 4, 5, 6]))
+
+    @pytest.mark.parametrize(
+        'array_like', [['b', 'd', 'a', 'c'], np.array(['b', 'd', 'a', 'c']), pd.Series(['b', 'd', 'a', 'c'])])
+    def test_order_by_array_like(self, array_like):
+        ch = chartify.Chart(x_axis_type='categorical')
+        ch.plot.scatter(self.data1, ['category1'], 'number1', categorical_order_by=array_like)
+        ch.plot.bar(self.data1, ['category1'], 'number1', categorical_order_by=array_like)
+
+        self._assert_order_by_array_like(ch)
+
+    @pytest.mark.parametrize('plot_method,categorical_order_by', [('bar', 'count'), ('scatter', 'values')])
+    def test_error(self, plot_method, categorical_order_by):
+        ch = chartify.Chart(x_axis_type='categorical', y_axis_type='linear')
+        with pytest.raises(ValueError):
+            plot_method = getattr(ch.plot, plot_method)
+            plot_method(self.data1, ['category1'], 'number1', categorical_order_by=categorical_order_by)
+
+
 def test_categorical_axis_type_casting():
     """Categorical axis plotting breaks for non-str types.
     Test that type casting is performed correctly"""


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines <https://github.com/spotify/chartify/blob/master/CONTRIBUTING.rst>
2. If the PR is unfinished, please prefix the subject line with [WIP], [DRAFT], or [RFC].
-->

**What this PR does / why we need it**:
Fixes bug with categorical_order_by and numpy arrays / pandas series
**Which issue(s) this PR fixes**
<!-- optional; in `fixes #<issue number>, fixes #<issue_number>, ...` format, will close the issue(s) when PR gets merged: -->
Fixes #74 

**Special notes for your reviewer**:
While writing the tests I discovered some weirdness in the chart data:
- the data for bar charts (and all other plots using `PlotMixedTypeXY._construct_source`) is in order of the specified ordering
- the scatter data is in the initial order (i.e. not ordered)

Nevertheless, in the chart, the data is displayed correctly, because not the order of the chart data defines the category order but the order of the factors of `bokeh.plotting.figure.x_range` (vertical) or `bokeh.plotting.figure.y_range` (horizontal).
And that is set by `PlotMixedTypeXY._set_categorical_axis_default_factors`.

What happens is that:
- for plots using `PlotMixedTypeXY._construct_source`, **the data gets sorted** and then the `x_range` is set accordingly
- for a scatter plot, factors are sorted and `x_range.factors` is set but **the actual data does not get sorted**

So it seems like sorting the actual data (like in `_construct_source`) is unnecessary as bokeh does not consider the order of the data itself but instead maps the observations to the corresponding factors in the `x_range`.

I think this can be addressed in a separate issue.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, start the release note with the string "action required: ".
2. If no release note is required, just write "NONE".
-->
```release-note
Support ordering categories using array_like (numpy array, pandas series)
```
