### PR TITLE
Documentation Build Fix

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,43 @@
+# Read the Docs configuration file for Sphinx projects
+
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+
+# Required
+
+version: 2
+
+
+# Set the OS, Python version and other tools you might need
+
+build:
+
+  os: ubuntu-22.04
+
+  tools:
+
+    python: "3.11"
+
+
+# Build documentation in the "docs/" directory with Sphinx
+sphinx:
+
+  configuration: docs/conf.py
+
+# Optionally build your docs in additional formats such as PDF and ePub
+formats:
+   - pdf
+   - epub
+
+
+# Optional but recommended, declare the Python requirements required
+
+# to build your documentation
+
+# See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
+
+python:
+
+   install:
+
+   - requirements: requirements_dev.txt

--- a/README.rst
+++ b/README.rst
@@ -77,4 +77,4 @@ This project adheres to the `Open Code of Conduct <https://github.com/spotify/co
 Contributing
 ------------
 
-`See the contributing docs <CONTRIBUTING.rst>`_.
+`See the contributing docs <https://github.com/spotify/chartify/blob/master/CONTRIBUTING.rst>`_.

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -32,13 +32,13 @@ You can either clone the public repository:
 
 .. code-block:: console
 
-    $ git clone git://github.com/cphalpert/chartify
+    $ git clone git://github.com/spotify/chartify
 
 Or download the `tarball`_:
 
 .. code-block:: console
 
-    $ curl  -OL https://github.com/cphalpert/chartify/tarball/master
+    $ curl  -OL https://github.com/spotify/chartify/tarball/master
 
 Once you have a copy of the source, you can install it with:
 
@@ -47,5 +47,5 @@ Once you have a copy of the source, you can install it with:
     $ python setup.py install
 
 
-.. _Github repo: https://github.com/cphalpert/chartify
-.. _tarball: https://github.com/cphalpert/chartify/tarball/master
+.. _Github repo: https://github.com/spotify/chartify
+.. _tarball: https://github.com/spotify/chartify/tarball/master


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines <https://github.com/spotify/chartify/blob/master/CONTRIBUTING.rst>
2. If the PR is unfinished, please prefix the subject line with [WIP], [DRAFT], or [RFC].
-->

**What this PR does / why we need it**:

The build for the documentation seems to have been broken for a while, as mentioned in #42. Additionally, readthedocs are soon deprecating the existing config methodology in favor of the .readthedocs.yaml file, so all builds not using this by 25th September will fail automatically (see https://blog.readthedocs.com/migrate-configuration-v2/). 

This PR fixes the documentation build and migrates to the new .readthedocs.yaml config file, while also fixing a few of the broken links as mentioned in #160.

I've tested the docs build on my fork (see https://chartify-lrjball.readthedocs.io/en/latest/index.html) and it all builds successfully, reflecting the latest state of the package (for example the history tab now shows all of the latest releases) and without the broken links.

Note, the previous config for the docs was specified in the web portal for readthedocs which is only accessible to the project owner, but the .readthedocs.yaml file will override these config values so it should work once merged in without requiring any further changes in the readthedocs portal.

**Which issue(s) this PR fixes**
<!-- optional; in `fixes #<issue number>, fixes #<issue_number>, ...` format, will close the issue(s) when PR gets merged: -->
Fixes #42, Fixes #160

