### PR TITLE
Removed major version cap to support pandas>=2 and scipy>=2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
-pandas>=1.2.0,<2.0.0
+pandas>=1.2.0
 Pillow>=9.1.0
 # Avoid selenium bug:
 # https://github.com/SeleniumHQ/selenium/issues/5296
 selenium>=4.0.0
 bokeh>=3.0.0
-scipy>=1.6.0,<2.0.0
+scipy>=1.6.0
 ipykernel>=6.0
 ipython>=7.17.0
 pyyaml>=6.0.0


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove major version requirement caps for pandas and scipy. This enables support for the current major release of pandas.

**Which issue(s) this PR fixes**
Fixes #166