### PR TITLE
Release 4.0.5

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,10 @@
 =======
 History
 =======
+4.0.5 (2023-10-12)
+------------------
+
+* Relaxed scipy and pandas version requirements to allow verions 2.x
 
 4.0.4 (2023-08-23)
 ------------------

--- a/chartify/__init__.py
+++ b/chartify/__init__.py
@@ -23,7 +23,7 @@ from chartify import examples
 
 __author__ = """Chris Halpert"""
 __email__ = "chalpert@spotify.com"
-__version__ = "4.0.4"
+__version__ = "4.0.5"
 
 _IPYTHON_INSTANCE = False
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
-pandas>=1.2.0,<2.0.0
+pandas>=1.2.0
 Pillow>=9.1.0
 # Avoid selenium bug:
 # https://github.com/SeleniumHQ/selenium/issues/5296
 selenium>=4.0.0
 bokeh>=3.0.0
-scipy>=1.6.0,<2.0.0
+scipy>=1.6.0
 ipykernel>=6.0
 ipython>=7.17.0
 pyyaml>=6.0.0


### PR DESCRIPTION
What this PR does / why we need it:
Remove major version requirement caps for pandas and scipy. This enables support for the current major release of pandas.

Which issue(s) this PR fixes
Fixes https://github.com/spotify/chartify/issues/166