### PR TITLE
Remove references to Spotify FOSS Slack

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,8 +1,3 @@
-<!-- This form is for bug reports and feature requests ONLY!
-
-If you're looking for help, please find us on [Spotify's open source Slack organization](https://slackin.spotify.com) in the #chartify channel.
--->
-
 **Is this a BUG REPORT or FEATURE REQUEST?**:
 
 > Uncomment only one, leave it on its own line:

--- a/README.rst
+++ b/README.rst
@@ -60,8 +60,6 @@ Documentation available on `chartify.readthedocs.io <https://chartify.readthedoc
 Getting support
 ---------------
 
-Join #chartify on spotify-foss.slack.com (`Get an invite <https://slackin.spotify.com/>`_)
-
 Use the `chartify tag on StackOverflow <https://stackoverflow.com/questions/tagged/chartify>`_.
 
 Resources


### PR DESCRIPTION
The FOSS Slack is being shut down. We will continue use GitHub issues, discussions, etc. for receiving feedback and bug reports.