### PR TITLE
Fix example: pd.melt(var_name=scalar)

### DIFF
--- a/chartify/examples.py
+++ b/chartify/examples.py
@@ -1268,7 +1268,7 @@ def style_color_palette_sequential():
         id_vars=["time"],
         value_vars=data.columns[1:],
         value_name="y",
-        var_name=["grouping"],
+        var_name="grouping",
     )
 
     # Plot the data


### PR DESCRIPTION
**What this PR does / why we need it**:

Pandas 2.2 is more strict than previous versions used to be. The `var_name` kwargs has always been a scalar, so give it one.

Before: 
```
[   26s] =================================== FAILURES ===================================
[   26s] ________________________________ test_examples _________________________________
[   26s] 
[   26s]     def test_examples():
[   26s]         # reload configuration
[   26s]         importlib.reload(chartify)
[   26s]     
[   26s]         excluded_examples = ['chart_show']
[   26s]         public_examples = [
[   26s]             attr for attr in dir(chartify.examples) if
[   26s]             callable(getattr(chartify.examples, attr))
[   26s]             and not attr.startswith("_")
[   26s]             and attr not in excluded_examples
[   26s]         ]
[   26s]         # Disable chart rendering
[   26s]         chartify.examples._OUTPUT_FORMAT = None
[   26s]         for example in public_examples:
[   26s] >           getattr(chartify.examples, example)()
[   26s] 
[   26s] tests/test_examples.py:36: 
[   26s] _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
[   26s] chartify/examples.py:45: in wrapper
[   26s]     return f(*args, **kwargs)
[   26s] chartify/examples.py:1304: in style_color_palette_diverging
[   26s]     data = pd.melt(
[   26s] _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
[   26s] 
[   26s] frame =            time  Very Unlikely  ...       Likely  Very Likely
[   26s] 0    2015-01-01      13.887274  ...   705.859449   804.6...1  ...  1801.226623  1901.008443
[   26s] 1096 2018-01-01    1095.555889  ...  1812.849633  1897.883901
[   26s] 
[   26s] [1097 rows x 6 columns]
[   26s] id_vars = ['time']
[   26s] value_vars = ['Very Unlikely', 'Unlikely', 'Neutral', 'Likely', 'Very Likely']
[   26s] var_name = ['grouping'], value_name = 'y', col_level = None, ignore_index = True
[   26s] 
[   26s]     @Appender(_shared_docs["melt"] % {"caller": "pd.melt(df, ", "other": "DataFrame.melt"})
[   26s]     def melt(
[   26s]         frame: DataFrame,
[   26s]         id_vars=None,
[   26s]         value_vars=None,
[   26s]         var_name=None,
[   26s]         value_name: Hashable = "value",
[   26s]         col_level=None,
[   26s]         ignore_index: bool = True,
[   26s]     ) -> DataFrame:
[   26s]         if value_name in frame.columns:
[   26s]             raise ValueError(
[   26s]                 f"value_name ({value_name}) cannot match an element in "
[   26s]                 "the DataFrame columns."
[   26s]             )
[   26s]         id_vars = ensure_list_vars(id_vars, "id_vars", frame.columns)
[   26s]         value_vars_was_not_none = value_vars is not None
[   26s]         value_vars = ensure_list_vars(value_vars, "value_vars", frame.columns)
[   26s]     
[   26s]         if id_vars or value_vars:
[   26s]             if col_level is not None:
[   26s]                 level = frame.columns.get_level_values(col_level)
[   26s]             else:
[   26s]                 level = frame.columns
[   26s]             labels = id_vars + value_vars
[   26s]             idx = level.get_indexer_for(labels)
[   26s]             missing = idx == -1
[   26s]             if missing.any():
[   26s]                 missing_labels = [
[   26s]                     lab for lab, not_found in zip(labels, missing) if not_found
[   26s]                 ]
[   26s]                 raise KeyError(
[   26s]                     "The following id_vars or value_vars are not present in "
[   26s]                     f"the DataFrame: {missing_labels}"
[   26s]                 )
[   26s]             if value_vars_was_not_none:
[   26s]                 frame = frame.iloc[:, algos.unique(idx)]
[   26s]             else:
[   26s]                 frame = frame.copy()
[   26s]         else:
[   26s]             frame = frame.copy()
[   26s]     
[   26s]         if col_level is not None:  # allow list or other?
[   26s]             # frame is a copy
[   26s]             frame.columns = frame.columns.get_level_values(col_level)
[   26s]     
[   26s]         if var_name is None:
[   26s]             if isinstance(frame.columns, MultiIndex):
[   26s]                 if len(frame.columns.names) == len(set(frame.columns.names)):
[   26s]                     var_name = frame.columns.names
[   26s]                 else:
[   26s]                     var_name = [f"variable_{i}" for i in range(len(frame.columns.names))]
[   26s]             else:
[   26s]                 var_name = [
[   26s]                     frame.columns.name if frame.columns.name is not None else "variable"
[   26s]                 ]
[   26s]         elif is_list_like(var_name):
[   26s] >           raise ValueError(f"{var_name=} must be a scalar.")
[   26s] E           ValueError: var_name=['grouping'] must be a scalar.
[   26s] 
[   26s] /usr/lib64/python3.10/site-packages/pandas/core/reshape/melt.py:100: ValueError
```

After:
:heavy_check_mark: Test passes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, start the release note with the string "action required: ".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
